### PR TITLE
prio3: Add domain separation

### DIFF
--- a/draft-patton-cfrg-vdaf.md
+++ b/draft-patton-cfrg-vdaf.md
@@ -1184,6 +1184,7 @@ leader share and helper share. These are called `encode_leader_share` and
 
 ~~~
 def measurement_to_input_shares(Prio3, _public_param, measurement):
+    dst = b"vdaf-00 Prio3" + Prio3.SUITE + b" "
     inp = Prio3.Flp.encode(measurement)
     k_joint_rand = zeros(Prio3.Prg.SEED_SIZE)
 
@@ -1198,7 +1199,7 @@ def measurement_to_input_shares(Prio3, _public_param, measurement):
         helper_input_share = Prio3.Prg.expand_into_vec(
             Prio3.Flp.Field,
             k_share,
-            b"input share",
+            dst + b"input share",
             Prio3.Flp.INPUT_LEN
         )
         leader_input_share = vec_sub(leader_input_share,
@@ -1224,13 +1225,13 @@ def measurement_to_input_shares(Prio3, _public_param, measurement):
     prove_rand = Prio3.Prg.expand_into_vec(
         Prio3.Flp.Field,
         gen_rand(Prio3.Prg.SEED_SIZE),
-        b"prove rand",
+        dst + b"prove rand",
         Prio3.Flp.PROVE_RAND_LEN
     )
     joint_rand = Prio3.Prg.expand_into_vec(
         Prio3.Flp.Field,
         k_joint_rand,
-        b"joint rand",
+        dst + b"joint rand",
         Prio3.Flp.JOINT_RAND_LEN
     )
     proof = Prio3.Flp.prove(inp, prove_rand, joint_rand)
@@ -1242,7 +1243,7 @@ def measurement_to_input_shares(Prio3, _public_param, measurement):
         helper_proof_share = Prio3.Prg.expand_into_vec(
             Prio3.Flp.Field,
             k_share,
-            b"proof share",
+            dst + b"proof share",
             Prio3.Flp.PROOF_LEN
         )
         leader_proof_share = vec_sub(leader_proof_share,
@@ -1298,11 +1299,12 @@ make use of encoding and decoding methods defined in {{prio3-helper-functions}}.
 
 ~~~
 def prep_init(Prio3, verify_param, _agg_param, nonce, input_share):
+    dst = b"vdaf-00 Prio3" + Prio3.SUITE + b" "
     (j, k_query_init) = verify_param
 
     (input_share, proof_share, k_blind, k_hint) = \
         Prio3.decode_leader_share(input_share) if j == 0 else \
-        Prio3.decode_helper_share(input_share)
+        Prio3.decode_helper_share(dst, input_share)
 
     out_share = Prio3.Flp.truncate(input_share)
 
@@ -1310,7 +1312,7 @@ def prep_init(Prio3, verify_param, _agg_param, nonce, input_share):
     query_rand = Prio3.Prg.expand_into_vec(
         Prio3.Flp.Field,
         k_query_rand,
-        b"query rand",
+        dst + b"query rand",
         Prio3.Flp.QUERY_RAND_LEN
     )
     joint_rand, k_joint_rand, k_joint_rand_share = [], None, None
@@ -1322,7 +1324,7 @@ def prep_init(Prio3, verify_param, _agg_param, nonce, input_share):
         joint_rand = Prio3.Prg.expand_into_vec(
             Prio3.Flp.Field,
             k_joint_rand,
-            b"joint rand",
+            dst + b"joint rand",
             Prio3.Flp.JOINT_RAND_LEN
         )
     verifier_share = Prio3.Flp.query(input_share,
@@ -1434,17 +1436,17 @@ def encode_helper_share(Prio3,
         encoded += k_hint
     return encoded
 
-def decode_helper_share(Prio3, encoded):
+def decode_helper_share(Prio3, dst, encoded):
     l = Prio3.Prg.SEED_SIZE
     k_input_share, encoded = encoded[:l], encoded[l:]
     input_share = Prio3.Prg.expand_into_vec(Prio3.Flp.Field,
                                             k_input_share,
-                                            b"input share",
+                                            dst + b"input share",
                                             Prio3.Flp.INPUT_LEN)
     k_proof_share, encoded = encoded[:l], encoded[l:]
     proof_share = Prio3.Prg.expand_into_vec(Prio3.Flp.Field,
                                             k_proof_share,
-                                            b"proof share",
+                                            dst + b"proof share",
                                             Prio3.Flp.PROOF_LEN)
     k_blind, k_hint = None, None
     if Prio3.Flp.JOINT_RAND_LEN > 0:

--- a/poc/common.sage
+++ b/poc/common.sage
@@ -5,6 +5,14 @@ from typing import List, TypeVar
 import struct
 import os
 
+
+# Document version, reved with each new draft.
+#
+# NOTE The CFRG has not yet adopted this spec. Version "vdaf-00" will match
+# draft-irtf-cfrg-vdaf-00.
+VERSION = b"vdaf-00"
+
+
 # Primitive types
 Bool = bool
 Bytes = bytes


### PR DESCRIPTION
Bind the derivation of field elements to the document name and the
"suite", consisting of the PRG and FLP.