### PR TITLE
poc: Library compatibility

### DIFF
--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -1,10 +1,18 @@
 # Pseudorandom number generators (PRGs).
 
 from __future__ import annotations
-from Crypto.Cipher import AES
-from Crypto.Hash import CMAC
-from Crypto.Util import Counter
-from Crypto.Util.number import bytes_to_long
+try:
+    # Default: use PyCryptodome installed in its drop-in replacement mode.
+    from Crypto.Cipher import AES
+    from Crypto.Hash import CMAC
+    from Crypto.Util import Counter
+    from Crypto.Util.number import bytes_to_long
+except ImportError:
+    # Fallback: use PyCryptodome installed independently.
+    from Cryptodome.Cipher import AES
+    from Cryptodome.Hash import CMAC
+    from Cryptodome.Util import Counter
+    from Cryptodome.Util.number import bytes_to_long
 from sagelib.common import OS2IP, Bytes, Error, Unsigned, zeros, gen_rand
 
 

--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -68,7 +68,7 @@ class PrgAes128(Prg):
 
         # CTR-mode encryption of the all-zero string of the desired
         # length and using a fixed, all-zero IV.
-        counter = Counter.new(128, initial_value=block)
+        counter = Counter.new(int(128), initial_value=block)
         cipher = AES.new(self.key, AES.MODE_CTR, counter=counter)
         stream = cipher.encrypt(zeros(offset + length))
         return stream[-length:]


### PR DESCRIPTION
This fixes a couple hiccups I ran into when running the Sage implementation with some older libraries from my distro. (sagemath 9.0-1ubuntu4 and python3-pycryptodome 3.6.1-2build4) I added a fallback to import PyCryptodome from either of its supported names, and added a conversion from `sage.rings.integer.Integer` to `int` in one place. The second change addresses a ctypes error I got from a PyCryptodome call; presumably newer versions of Sage cooperate with ctypes better on type coercion.